### PR TITLE
Make pyzmq an optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
       url='https://github.com/SkygearIO/py-skygear',
       license='Apache License, Version 2.0',
       install_requires=[
-            'pyzmq>=14.7',
             'psycopg2>=2.6.1',
             'SQLAlchemy>=1.0.8',
             'strict-rfc3339>=0.5',
@@ -51,8 +50,14 @@ setup(
             'ConfigArgParse>=0.10.0',
             'werkzeug>=0.11.0',
       ],
+      extras_require={
+            'zmq': ['pyzmq>=14.7'],
+      },
       cmdclass= {'test': PyTest},
-      tests_require=['pytest'],
+      tests_require=[
+            'skygear[zmq]',
+            'pytest',
+      ],
       entry_points={
           'console_scripts': [
               'py-skygear = skygear.bin:main'


### PR DESCRIPTION
`pyzmq` takes a long time to install and it is a waste of computation power for those not using the zmq transport (it adds up if they build their own docker image on py-skygear)

This PR makes the pyzmq an optional feature. For people using the zmq transport, they could install py-skygear using the following command:

```bash
> pip install py-skygear[zmq]
```
