### PR TITLE
Remove paging logic from py-skygear

### DIFF
--- a/skygear/restful.py
+++ b/skygear/restful.py
@@ -128,50 +128,25 @@ class RestfulRecord(RestfulResource):
         except ValueError:
             return None
 
-    def _sort_descriptors(self, field, direction):
-        if not field:
-            return []
-
-        if direction not in ['asc', 'desc']:
-            direction = 'asc'
-
-        return [
-                [{'$val': field, '$type': 'keypath'}, direction]
-                ]
-
     def predicate(self):
         return None
+
+    def query_options(self):
+        return {}
 
     def index(self):
         """
         List records by querying the database.
-
-        The resource accepts the following query string parameters:
-        * _page - the page number to return, first page is 1
-        * _perPage - the number of results per page
-        * _sortDir - the sort order, either 'asc' or 'desc'
-        * _sortField - the name of the field to sort
         """
-        try:
-            limit = int(self.request.values.get('_perPage', 100))
-        except ValueError:
-            limit = 100
-        try:
-            offset = (int(self.request.values.get('_page', 0))-1) * limit
-        except ValueError:
-            offset = 0
-        sort_direction = self.request.values.get('_sortDir', 'asc').lower()
-        sort_field = self.request.values.get('_sortField', None)
+        options = self.query_options() or {}
+        predicate = self.predicate()
+        if predicate is not None:
+            options['predicate'] = predicate
 
         return self._send_multi('record:query',
                                 database_id=self.database_id,
                                 record_type=self.record_type,
-                                limit=limit,
-                                offset=offset,
-                                sort=self._sort_descriptors(sort_field,
-                                                            sort_direction),
-                                count=True,
-                                predicate=self.predicate()
+                                **options
                                 )
 
     def create(self):

--- a/skygear/tests/test_restful.py
+++ b/skygear/tests/test_restful.py
@@ -186,6 +186,12 @@ class MockRestfulRecord(restful.RestfulRecord):
     def get_payload(self):
         return {'_id': 'sample/1', 'data': 'json'}
 
+    def predicate(self):
+        return []
+
+    def query_options(self):
+        return {'count': True}
+
 
 class TestRestfulRecord(unittest.TestCase):
     def test_access_token_header(self):
@@ -211,16 +217,12 @@ class TestRestfulRecord(unittest.TestCase):
         resource = MockRestfulRecord()
 
         with patch.object(resource, '_send_multi') as mock:
-            query_string = '_page=1&_perPage=30&_sortDir=DESC&_sortField=id'
-            resource.request = create_request(query_string=query_string)
+            resource.request = create_request()
             mock.return_value = [{'data': 'json'}]
             assert resource.index() == [{'data': 'json'}]
-            sorts = [[{'$val': 'id', '$type': 'keypath'}, 'desc']]
             mock.assert_called_once_with('record:query', database_id='_public',
                                          record_type='sample',
-                                         count=True,
-                                         predicate=None,
-                                         limit=30, offset=0, sort=sorts)
+                                         predicate=[], count=True)
 
     def test_handle_request_create(self):
         resource = MockRestfulRecord()


### PR DESCRIPTION
This removes ng-admin paging logic from py-skygear. These should have
been implemented by a plugin of py-skygear, instead of including them
in py-skgyear core.