### PR TITLE
Set the container default before loading source

### DIFF
--- a/skygear/bin.py
+++ b/skygear/bin.py
@@ -58,12 +58,11 @@ def load_source_or_exit(source):
 
 
 def run_plugin(options):
-    load_source_or_exit(options.plugin)
-
     SkygearContainer.set_default_app_name(options.appname)
     SkygearContainer.set_default_endpoint(options.skygear_endpoint)
     SkygearContainer.set_default_apikey(options.apikey)
 
+    load_source_or_exit(options.plugin)
     log.debug("Install signal handler for SIGTERM")
     signal.signal(signal.SIGTERM, sigterm_handler)
 


### PR DESCRIPTION
Problem:
When a user want to send_action to Skygear on bootsrtap, he will try to
instantiate a SkygearContianer instance. However the skygear container
is not yet loaded the default config from environment variable. It make the
developer have to load it from the environment by themselves.

Fix:
Set the container default before attempting to load the plugin source, when
loading the plugin source. Developer got a SkygearContainer with proper
defaults.