### PR TITLE
Check if a table exists in schema

### DIFF
--- a/skygear/utils/db.py
+++ b/skygear/utils/db.py
@@ -77,13 +77,35 @@ def _set_search_path(db):
     db.execute(sql)
 
 
+def _full_table_name(schema_name, name):
+    """
+    Return the full name of a table, which includes the schema name.
+    """
+    return "{}.{}".format(schema_name, name)
+
+
 def get_table(name):
+    """
+    Returns the table object with the specified name from the reflected
+    database.
+
+    An exception is raised if the table does not exist.
+    """
     schema_name = _get_schema_name()
     try:
-        return _get_metadata().tables["{}.{}".format(schema_name, name)]
+        return _get_metadata().tables[_full_table_name(schema_name, name)]
     except KeyError:
         raise Exception("No table of name '{}' exists in schema '{}'.",
                         name, schema_name)
+
+
+def has_table(name):
+    """
+    Returns whether a table with the specified name exists in the reflected
+    database schema.
+    """
+    schema_name = _get_schema_name()
+    return _full_table_name(schema_name, name) in _get_metadata().tables
 
 
 @contextlib.contextmanager

--- a/skygear/utils/tests/test_db.py
+++ b/skygear/utils/tests/test_db.py
@@ -76,3 +76,9 @@ class TestReflectTable(BaseTestCase):
     def test_get_table_nonexistent(self):
         with self.assertRaises(Exception):
             db.get_table('something')
+
+    def test_has_table(self):
+        assert db.has_table('note') is True
+
+    def test_has_table_nonexistent(self):
+        assert db.has_table('something') is False


### PR DESCRIPTION
This commit adds a function to check if a table of the specified name
exists in the database schema. The old method was to call get_table and
catch the Exception if the table does not exist.