### PR TITLE
Implement serving static assets for development

### DIFF
--- a/skygear/assets.py
+++ b/skygear/assets.py
@@ -15,6 +15,8 @@ import os.path
 import logging
 import shutil
 
+from .utils.assets import StaticAssetsLoader
+
 
 log = logging.getLogger(__name__)
 
@@ -37,10 +39,13 @@ class StaticAssetsCollector:
             raise CollectorException('Prefix {} is incorrect.'.format(prefix))
         return prefix_path
 
-    def collect(self, prefix, path):
+    def collect(self, prefix, loader):
+        if not isinstance(loader, StaticAssetsLoader):
+            raise ValueError('The second argument must be an instance '
+                    'of StaticAssetsLoader.')
         prefix_path = self._prefix_path(prefix)
         log.debug('Prefix path is %s', prefix_path)
-        shutil.copytree(path, prefix_path, symlinks=True)
+        loader.copy_into(prefix_path)
 
     def clean(self):
         shutil.rmtree(self.dist)

--- a/skygear/assets.py
+++ b/skygear/assets.py
@@ -1,0 +1,46 @@
+# Copyright 2015 Oursky Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os.path
+import logging
+import shutil
+
+
+log = logging.getLogger(__name__)
+
+
+class CollectorException(Exception):
+    pass
+
+
+class StaticAssetsCollector:
+    def __init__(self, dist):
+        self.dist = os.path.abspath(dist)
+
+    @property
+    def base_path(self):
+        return os.path.join(self.dist, 'static')
+
+    def _prefix_path(self, prefix):
+        prefix_path = os.path.abspath(os.path.join(self.base_path, prefix))
+        if not prefix_path.startswith(self.base_path):
+            raise CollectorException('Prefix {} is incorrect.'.format(prefix))
+        return prefix_path
+
+    def collect(self, prefix, path):
+        prefix_path = self._prefix_path(prefix)
+        log.debug('Prefix path is %s', prefix_path)
+        shutil.copytree(path, prefix_path, symlinks=True)
+
+    def clean(self):
+        shutil.rmtree(self.dist)

--- a/skygear/assets.py
+++ b/skygear/assets.py
@@ -47,7 +47,7 @@ class StaticAssetsCollector:
     def collect(self, prefix, loader):
         if not isinstance(loader, StaticAssetsLoader):
             raise ValueError('The second argument must be an instance '
-                    'of StaticAssetsLoader.')
+                             'of StaticAssetsLoader.')
         prefix_path = self._prefix_path(prefix)
         log.debug('Prefix path is %s', prefix_path)
         loader.copy_into(prefix_path)
@@ -61,8 +61,8 @@ def serve_static_assets(request, basepath):
     Serve static assets with the given request object.
     """
     if not request.path.startswith(basepath):
-        raise ValueError('Request path does not start with basepath ""' \
-                .format(basepath))
+        raise ValueError('Request path does not start with basepath ""'
+                         .format(basepath))
 
     path = request.path[len(basepath):]
     try:

--- a/skygear/bin.py
+++ b/skygear/bin.py
@@ -67,6 +67,8 @@ def load(options):
     from .decorators import static_assets, handler
     from .assets import serve_static_assets
 
+    STATIC_ASSETS_PREFIX = 'static'
+
     # If the directory `public_html` exists in the current directory,
     # assume the user want to publish its content as static assets.
     auto_assets_dir = os.path.abspath('public_html')
@@ -76,7 +78,6 @@ def load(options):
             return auto_assets_dir
 
     # Create handler for serving static assets.
-    STATIC_ASSETS_PREFIX = 'static'
     @handler('{}/'.format(STATIC_ASSETS_PREFIX))
     @handler(STATIC_ASSETS_PREFIX)
     def work(request):

--- a/skygear/bin.py
+++ b/skygear/bin.py
@@ -64,15 +64,24 @@ def load_source_or_exit(source):
 
 
 def load(options):
+    from .decorators import static_assets, handler
+    from .assets import serve_static_assets
+
     # If the directory `public_html` exists in the current directory,
     # assume the user want to publish its content as static assets.
     auto_assets_dir = os.path.abspath('public_html')
     if os.path.exists(auto_assets_dir):
-        from .decorators import static_assets
-
         @static_assets('')
         def auto_assets():
             return auto_assets_dir
+
+    # Create handler for serving static assets.
+    STATIC_ASSETS_PREFIX = 'static'
+    @handler('{}/'.format(STATIC_ASSETS_PREFIX))
+    @handler(STATIC_ASSETS_PREFIX)
+    def work(request):
+        return serve_static_assets(request,
+                                   '/{}/'.format(STATIC_ASSETS_PREFIX))
 
     load_source_or_exit(options.plugin)
 

--- a/skygear/commands/static_assets.py
+++ b/skygear/commands/static_assets.py
@@ -3,7 +3,7 @@ import os
 
 from ..options import options
 from ..registry import get_registry
-from ..utils.assets import CollectorException, StaticAssetsCollector
+from ..assets import CollectorException, StaticAssetsCollector
 
 _registry = get_registry()
 log = logging.getLogger(__name__)

--- a/skygear/commands/static_assets.py
+++ b/skygear/commands/static_assets.py
@@ -1,9 +1,10 @@
 import logging
 import os
 
+from ..assets import CollectorException, StaticAssetsCollector
 from ..options import options
 from ..registry import get_registry
-from ..assets import CollectorException, StaticAssetsCollector
+from ..utils.assets import DirectoryStaticAssetsLoader, StaticAssetsLoader
 
 _registry = get_registry()
 log = logging.getLogger(__name__)
@@ -27,10 +28,16 @@ def collect_static_assets():
         return collector.dist
 
     for prefix, func in _registry.static_assets.items():
-        log.info('Static assets %s', prefix)
-        path = func()
+        loader = func()
+        if not loader:
+            continue
+        elif not isinstance(loader, StaticAssetsLoader):
+            raise ValueError('Function decorated with static_assets '
+                    'must return a string or '
+                    'an instance of StaticAssetsLoader')
         try:
-            collector.collect(prefix, path)
+            log.info('Static assets %s', prefix)
+            collector.collect(prefix, loader)
         except CollectorException as e:
             log.error(str(e))
             exit(1)

--- a/skygear/commands/static_assets.py
+++ b/skygear/commands/static_assets.py
@@ -4,7 +4,7 @@ import os
 from ..assets import CollectorException, StaticAssetsCollector
 from ..options import options
 from ..registry import get_registry
-from ..utils.assets import DirectoryStaticAssetsLoader, StaticAssetsLoader
+from ..utils.assets import StaticAssetsLoader
 
 _registry = get_registry()
 log = logging.getLogger(__name__)
@@ -33,8 +33,8 @@ def collect_static_assets():
             continue
         elif not isinstance(loader, StaticAssetsLoader):
             raise ValueError('Function decorated with static_assets '
-                    'must return a string or '
-                    'an instance of StaticAssetsLoader')
+                             'must return a string or '
+                             'an instance of StaticAssetsLoader')
         try:
             log.info('Static assets %s', prefix)
             collector.collect(prefix, loader)

--- a/skygear/registry.py
+++ b/skygear/registry.py
@@ -102,7 +102,7 @@ class Registry:
                 subpath = request_path[len(prefix)+1:]
                 return loader(), subpath
         raise KeyError('Unable to find static assets loader with '
-                'request_path "{}"'.format(request_path))
+                       'request_path "{}"'.format(request_path))
 
     def func_list(self):
         return self.param_map

--- a/skygear/registry.py
+++ b/skygear/registry.py
@@ -96,6 +96,14 @@ class Registry:
     def register_static_assets(self, prefix, func):
         self.static_assets[prefix] = func
 
+    def get_static_assets(self, request_path):
+        for prefix, loader in self.static_assets.items():
+            if request_path.startswith(prefix):
+                subpath = request_path[len(prefix)+1:]
+                return loader(), subpath
+        raise KeyError('Unable to find static assets loader with '
+                'request_path "{}"'.format(request_path))
+
     def func_list(self):
         return self.param_map
 

--- a/skygear/tests/test_assets.py
+++ b/skygear/tests/test_assets.py
@@ -1,0 +1,60 @@
+# Copyright 2015 Oursky Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os.path
+import shutil
+import tempfile
+import unittest
+
+from .. import assets
+
+
+class TestStaticAssetsCollector(unittest.TestCase):
+    def setUp(self):
+        self.dist = tempfile.mkdtemp()
+        self.collector = assets.StaticAssetsCollector(self.dist)
+
+    def tearDown(self):
+        if os.path.exists(self.dist):
+            shutil.rmtree(self.dist)
+
+    def test_clean(self):
+        self.collector.clean()
+        assert os.path.exists(self.dist) is False
+
+    def test_collect(self):
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmp_dir, 'index.txt'), 'w') as f:
+                f.write('Hello World!')
+
+            self.collector.collect('hello-world', tmp_dir)
+        finally:
+            shutil.rmtree(tmp_dir)
+
+        collected_path = os.path.join(self.collector.base_path,
+                                      'hello-world',
+                                      'index.txt')
+        with open(collected_path, 'r') as f:
+            assert f.read() == 'Hello World!'
+
+    def test_collect_incorrect_prefix(self):
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmp_dir, 'index.txt'), 'w') as f:
+                f.write('Hello World!')
+
+            with self.assertRaises(assets.CollectorException):
+                self.collector.collect('../hello-world', tmp_dir)
+        finally:
+            shutil.rmtree(tmp_dir)

--- a/skygear/tests/test_assets.py
+++ b/skygear/tests/test_assets.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 from .. import assets
+from ..utils.assets import DirectoryStaticAssetsLoader
 
 
 class TestStaticAssetsCollector(unittest.TestCase):
@@ -38,7 +39,8 @@ class TestStaticAssetsCollector(unittest.TestCase):
             with open(os.path.join(tmp_dir, 'index.txt'), 'w') as f:
                 f.write('Hello World!')
 
-            self.collector.collect('hello-world', tmp_dir)
+            self.collector.collect('hello-world',
+                                   DirectoryStaticAssetsLoader(tmp_dir))
         finally:
             shutil.rmtree(tmp_dir)
 
@@ -55,6 +57,7 @@ class TestStaticAssetsCollector(unittest.TestCase):
                 f.write('Hello World!')
 
             with self.assertRaises(assets.CollectorException):
-                self.collector.collect('../hello-world', tmp_dir)
+                self.collector.collect('../hello-world',
+                                       DirectoryStaticAssetsLoader(tmp_dir))
         finally:
             shutil.rmtree(tmp_dir)

--- a/skygear/tests/test_decorators.py
+++ b/skygear/tests/test_decorators.py
@@ -18,6 +18,7 @@ from werkzeug.wrappers import Request
 
 from .. import decorators as d
 from ..registry import Registry  # noqa
+from ..utils.assets import DirectoryStaticAssetsLoader
 
 
 class TestHookDecorators(unittest.TestCase):
@@ -105,6 +106,9 @@ class TestStaticAssetsDecorator(unittest.TestCase):
     def test_register(self, mock):
         @d.static_assets('/admin')
         def fn():
-            pass
+            return '/tmp/public'
 
         mock.assert_called_with('/admin', ANY)
+        loader = fn()
+        assert isinstance(loader, DirectoryStaticAssetsLoader)
+        assert loader.dirpath == '/tmp/public'

--- a/skygear/tests/test_registry.py
+++ b/skygear/tests/test_registry.py
@@ -154,6 +154,7 @@ class TestRegistry(unittest.TestCase):
             pass
 
         loader = Loader()
+
         def fn():
             return loader
 

--- a/skygear/tests/test_registry.py
+++ b/skygear/tests/test_registry.py
@@ -148,3 +148,18 @@ class TestRegistry(unittest.TestCase):
 
         assert len(registry.static_assets) == 1
         assert registry.static_assets['admin'] == fn
+
+    def test_get_static_assets(self):
+        class Loader:
+            pass
+
+        loader = Loader()
+        def fn():
+            return loader
+
+        registry = Registry()
+        registry.static_assets['admin'] = fn
+        got_loader, subpath = registry.get_static_assets('admin/apple/pie')
+
+        assert got_loader is loader
+        assert subpath == 'apple/pie'

--- a/skygear/utils/assets.py
+++ b/skygear/utils/assets.py
@@ -12,38 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
-import logging
 import os
-import shutil
 
-log = logging.getLogger(__name__)
-
-
-class CollectorException(Exception):
-    pass
-
-
-class StaticAssetsCollector:
-    def __init__(self, dist):
-        self.dist = os.path.abspath(dist)
-
-    @property
-    def base_path(self):
-        return os.path.join(self.dist, 'static')
-
-    def _prefix_path(self, prefix):
-        prefix_path = os.path.abspath(os.path.join(self.base_path, prefix))
-        if not prefix_path.startswith(self.base_path):
-            raise CollectorException('Prefix {} is incorrect.'.format(prefix))
-        return prefix_path
-
-    def collect(self, prefix, path):
-        prefix_path = self._prefix_path(prefix)
-        log.debug('Prefix path is %s', prefix_path)
-        shutil.copytree(path, prefix_path, symlinks=True)
-
-    def clean(self):
-        shutil.rmtree(self.dist)
 
 
 def directory_assets(path='static'):

--- a/skygear/utils/assets.py
+++ b/skygear/utils/assets.py
@@ -58,7 +58,7 @@ class DictStaticAssetsLoader(StaticAssetsLoader):
     def copy_into(self, path):
         for filename, content in self._dict.items():
             filepath = os.path.abspath(
-                    os.path.join(dest, _trim_abs_path(filename)))
+                    os.path.join(path, _trim_abs_path(filename)))
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
             with open(filepath, 'wb') as f:
                 f.write(content)
@@ -97,8 +97,7 @@ class PackageStaticAssetsLoader(StaticAssetsLoader):
     """
     def __init__(self, package_name, package_path):
         super().__init__()
-        from pkg_resources import DefaultProvider, ResourceManager, \
-                                  get_provider
+        from pkg_resources import ResourceManager, get_provider
         self.provider = get_provider(package_name)
         self.manager = ResourceManager()
         self.package_path = package_path
@@ -111,7 +110,6 @@ class PackageStaticAssetsLoader(StaticAssetsLoader):
                                                  self.resource_name(name))
 
     def copy_into(self, dest):
-        os.makedirs(dest, exist_ok=True)
         def _walk(subpath=None):
             """
             `_walk` copies files in a subdirectory to the destination. If
@@ -134,6 +132,8 @@ class PackageStaticAssetsLoader(StaticAssetsLoader):
                     print('writing to {}'.format(dest_name))
                     with open(dest_name, 'wb') as f:
                         f.write(self.get_asset(childpath))
+
+        os.makedirs(dest, exist_ok=True)
         _walk()
 
     def exists_asset(self, name):

--- a/skygear/utils/assets.py
+++ b/skygear/utils/assets.py
@@ -40,6 +40,9 @@ class StaticAssetsLoader:
         """
         pass
 
+    def exists_asset(self, name):
+        return False
+
 
 class DictStaticAssetsLoader(StaticAssetsLoader):
     """
@@ -59,6 +62,9 @@ class DictStaticAssetsLoader(StaticAssetsLoader):
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
             with open(filepath, 'wb') as f:
                 f.write(content)
+
+    def exists_asset(self, name):
+        return name in self._dict
 
 
 class DirectoryStaticAssetsLoader(StaticAssetsLoader):
@@ -80,6 +86,9 @@ class DirectoryStaticAssetsLoader(StaticAssetsLoader):
 
     def copy_into(self, dest):
         shutil.copytree(self.dirpath, dest, symlinks=True)
+
+    def exists_asset(self, name):
+        return os.path.exists(os.path.join(self.dirpath, name))
 
 
 def directory_assets(path='static'):

--- a/skygear/utils/tests/assets/content/index.txt
+++ b/skygear/utils/tests/assets/content/index.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/skygear/utils/tests/test_assets.py
+++ b/skygear/utils/tests/test_assets.py
@@ -12,52 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os.path
-import shutil
-import tempfile
 import unittest
 
 from .. import assets as assetsutils
-
-
-class TestStaticAssetsCollector(unittest.TestCase):
-    def setUp(self):
-        self.dist = tempfile.mkdtemp()
-        self.collector = assetsutils.StaticAssetsCollector(self.dist)
-
-    def tearDown(self):
-        if os.path.exists(self.dist):
-            shutil.rmtree(self.dist)
-
-    def test_clean(self):
-        self.collector.clean()
-        assert os.path.exists(self.dist) is False
-
-    def test_collect(self):
-        tmp_dir = tempfile.mkdtemp()
-        try:
-            with open(os.path.join(tmp_dir, 'index.txt'), 'w') as f:
-                f.write('Hello World!')
-
-            self.collector.collect('hello-world', tmp_dir)
-        finally:
-            shutil.rmtree(tmp_dir)
-
-        collected_path = os.path.join(self.collector.base_path,
-                                      'hello-world',
-                                      'index.txt')
-        with open(collected_path, 'r') as f:
-            assert f.read() == 'Hello World!'
-
-    def test_collect_incorrect_prefix(self):
-        tmp_dir = tempfile.mkdtemp()
-        try:
-            with open(os.path.join(tmp_dir, 'index.txt'), 'w') as f:
-                f.write('Hello World!')
-
-            with self.assertRaises(assetsutils.CollectorException):
-                self.collector.collect('../hello-world', tmp_dir)
-        finally:
-            shutil.rmtree(tmp_dir)
 
 
 class StaticAssetsHelperFunction(unittest.TestCase):

--- a/skygear/utils/tests/test_assets.py
+++ b/skygear/utils/tests/test_assets.py
@@ -19,10 +19,12 @@ from .. import assets as assetsutils
 
 class StaticAssetsHelperFunction(unittest.TestCase):
     def test_directory_assets(self):
-        assert assetsutils.directory_assets('hello-world') == \
-            os.path.abspath('hello-world')
+        loader = assetsutils.directory_assets('hello-world')
+        assert isinstance(loader, assetsutils.StaticAssetsLoader)
+        assert loader.dirpath == os.path.abspath('hello-world')
 
     def test_relative_assets(self):
+        loader = assetsutils.relative_assets('hello-world')
+        assert isinstance(loader, assetsutils.StaticAssetsLoader)
         expected = os.path.join(os.path.dirname(__file__), 'hello-world')
-        assert assetsutils.relative_assets('hello-world') == \
-            os.path.abspath(expected)
+        assert loader.dirpath == os.path.abspath(expected)


### PR DESCRIPTION
When py-skygear loads all the cloudcode and plugins, it creates an handler
for serving static assets declared using the `static_assets` decorator. The
static assets handler is able to serve static assets from a file system
directory or a directory in a python package.

connects #23