### PR TITLE
Do not serve static assets by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '2'
+
+services:
+  db:
+    image: mdillon/postgis:9.4
+    volumes:
+    - db_data:/var/lib/postgresql/data
+    ports:
+    - "5432:5432"
+
+  redis:
+    image: redis:3.0
+    volumes:
+    - redis_data:/data
+
+  app:
+    image: quay.io/skygeario/skygear-server:canary
+    ports:
+    - "3000:3000"
+    volumes:
+    - app_data:/go/src/app/data
+    links:
+    - db
+    - redis
+    command: skygear-server --http
+    environment:
+      # `db` in the following string should match the name of the database
+      # container above.
+      DATABASE_URL: postgresql://postgres:@db/postgres?sslmode=disable
+      REDISTEST: redis://redis:6379
+      API_KEY: changeme
+      MASTER_KEY: secret
+      APP_NAME: _
+      # GOMAXPROCS - The maximum number of Go threads for execution.
+      # When unspecified, the default is the number of CPU available, which
+      # is the recommended setting.
+      #GOMAXPROCS: 1
+      PLUGINS: PYTHON
+      PYTHON_TRANSPORT: http
+      PYTHON_PATH: http://plugin:8000
+
+  plugin:
+    build:
+      context: .
+      dockerfile: Dockerfile-development
+    command: py-skygear --http
+    volumes:
+    - .:/usr/src/app
+    environment:
+      DATABASE_URL: postgres://postgres@db/postgres?sslmode=disable
+      PUBSUB_URL: PUBSUB_URL=ws://app:3000/pubsub
+      SKYGEAR_ADDRESS: tcp://app:5555
+      SKYGEAR_ENDPOINT: http://app:3000
+      SKYGEAR_APIKEY: changeme
+      SKYGEAR_MASTERKEY: secret
+      SKYGEAR_APPNAME: _
+
+volumes:
+  redis_data:
+    driver: local
+  db_data:
+    driver: local
+  app_data:
+    driver: local

--- a/plugin.py
+++ b/plugin.py
@@ -1,0 +1,2 @@
+# This is a cloudcode plugin file.
+# This file is intentionally left blank.

--- a/skygear/bin.py
+++ b/skygear/bin.py
@@ -64,25 +64,27 @@ def load_source_or_exit(source):
 
 
 def load(options):
-    from .decorators import static_assets, handler
-    from .assets import serve_static_assets
-
-    STATIC_ASSETS_PREFIX = 'static'
-
     # If the directory `public_html` exists in the current directory,
     # assume the user want to publish its content as static assets.
     auto_assets_dir = os.path.abspath('public_html')
     if os.path.exists(auto_assets_dir):
+        from .decorators import static_assets
+
         @static_assets('')
         def auto_assets():
             return auto_assets_dir
 
     # Create handler for serving static assets.
-    @handler('{}/'.format(STATIC_ASSETS_PREFIX))
-    @handler(STATIC_ASSETS_PREFIX)
-    def work(request):
-        return serve_static_assets(request,
-                                   '/{}/'.format(STATIC_ASSETS_PREFIX))
+    if options.serve_static_assets:
+        STATIC_ASSETS_PREFIX = 'static'
+        from .decorators import handler
+        from .assets import serve_static_assets
+
+        @handler('{}/'.format(STATIC_ASSETS_PREFIX))
+        @handler(STATIC_ASSETS_PREFIX)
+        def work(request):
+            return serve_static_assets(request,
+                                       '/{}/'.format(STATIC_ASSETS_PREFIX))
 
     load_source_or_exit(options.plugin)
 

--- a/skygear/options.py
+++ b/skygear/options.py
@@ -59,6 +59,9 @@ def get_argument_parser():
                     help="Collect static assets to a directory")
     ap.add_argument('--force-assets', action='store_true',
                     help="Remove dist folder before proceeding")
+    ap.add_argument('--serve-static-assets', action='store_true',
+                    env_var='SKYGEAR_SERVE_STATIC_ASSETS',
+                    help="Enable to serve static asset from plugin process")
     ap.add_argument('plugin', nargs='?')
     return ap
 


### PR DESCRIPTION
Serving static assets from the plugin process by default causes problem for
environments which are complex enough to require multiple cloudcode.