### PR TITLE
Register citext in postgresql dialects

### DIFF
--- a/skygear/utils/db.py
+++ b/skygear/utils/db.py
@@ -18,6 +18,7 @@ import re
 
 import sqlalchemy as sa
 from sqlalchemy import schema
+from sqlalchemy.dialects.postgresql.base import ischema_names
 
 from ..container import SkygearContainer
 
@@ -25,6 +26,9 @@ _app_name_pattern = re.compile('[.:]')
 _engine = None
 _metadata = None
 _logger = logging.getLogger(__name__)
+
+# Register CIText to SQLAlchemy's Postgres reflection subsystem.
+ischema_names['citext'] = sa.types.TEXT
 
 
 def quotedIdentifier(s):


### PR DESCRIPTION
It take the assumption on the citext extension are on public schema, which
is related to skyegar-server migration issue at
https://github.com/SkygearIO/skygear-server/issues/53

connects #31