### PR TITLE
Make the zmq transmitter open worker thread

### DIFF
--- a/.lizard
+++ b/.lizard
@@ -1,0 +1,1 @@
+skygear/transmitter/zmq.py:run

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 script:
   - pylama skygear
   - coverage run --source skygear setup.py test
-  - python "`which lizard`" skygear -C 10 -w -i 0
+  - python "`which lizard`" skygear -C 10 -W .lizard -w -i 0
   - coverage report -m --omit *tests*
 
 before_deploy:

--- a/skygear/tests/test_zmq.py
+++ b/skygear/tests/test_zmq.py
@@ -69,7 +69,7 @@ class TestZmq(unittest.TestCase):
 
 def dead_router(count):
     """
-    This router will set malformat frame that crash the worker
+    This router will send malformed frame that crash the worker
     """
     context = zmq.Context()
     router = context.socket(zmq.ROUTER)
@@ -86,12 +86,3 @@ def dead_router(count):
         router.send_multipart(frames)
         i = i + 1
     router.close()
-
-
-class ErrorWorker(object):
-    def __init__(self):
-        pass
-
-    def __call__(self, addr, context, poller):
-        print('call')
-        raise KeyboardInterrupt

--- a/skygear/tests/test_zmq.py
+++ b/skygear/tests/test_zmq.py
@@ -1,0 +1,97 @@
+# Copyright 2015 Oursky Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import threading
+import time
+import unittest
+
+import zmq
+
+from ..transmitter.zmq import HEARTBEAT_INTERVAL, ZmqTransport
+
+ZMQ_ADDR = 'tcp://0.0.0.0:12345'
+
+
+class TestZmq(unittest.TestCase):
+    def test_numebr_of_thread_startup(self):
+        transport = ZmqTransport(ZMQ_ADDR, threading=5)
+        transport.start()
+        self.assertEqual(len(transport.threads), 5)
+        for t in transport.threads:
+            self.assertEqual(t.is_alive(), True)
+        transport.stop()
+        time.sleep(HEARTBEAT_INTERVAL * 2)
+        for t in transport.threads:
+            self.assertEqual(t.is_alive(), False)
+
+    def test_worker_dead(self):
+        t = threading.Thread(target=dead_router, args=(3,), daemon=True)
+        t.start()
+        transport = ZmqTransport(ZMQ_ADDR, threading=3)
+        transport.start()
+        liveness = [_t.is_alive() for _t in transport.threads]
+        self.assertEqual(liveness, [True, True, True])
+        time.sleep(HEARTBEAT_INTERVAL * 5)
+        liveness = [_t.is_alive() for _t in transport.threads]
+        self.assertEqual(liveness, [False, False, False])
+        transport.stop()
+        self.assertEqual(t.is_alive(), False)
+
+    def test_maintain_worker_count(self):
+        t = threading.Thread(target=dead_router, args=(3,), daemon=True)
+        t.start()
+        transport = ZmqTransport(ZMQ_ADDR, threading=3)
+        transport.start()
+        transport_t = threading.Thread(
+            target=transport.maintain_workers_count,
+            daemon=True)
+        transport_t.start()
+        liveness = [_t.is_alive() for _t in transport.threads]
+        self.assertEqual(liveness, [True, True, True])
+        time.sleep(HEARTBEAT_INTERVAL * 3)
+        liveness = [_t.is_alive() for _t in transport.threads]
+        self.assertEqual(liveness, [True, True, True])
+        transport.stop()
+        time.sleep(HEARTBEAT_INTERVAL)
+        self.assertEqual(transport_t.is_alive(), False)
+        self.assertEqual(t.is_alive(), False)
+
+
+def dead_router(count):
+    """
+    This router will set malformat frame that crash the worker
+    """
+    context = zmq.Context()
+    router = context.socket(zmq.ROUTER)
+    router.bind(ZMQ_ADDR)
+    poller = zmq.Poller()
+    poller.register(router, zmq.POLLIN)
+    i = 0
+    while i < count:
+        router.poll()
+        frames = router.recv_multipart()
+        if not frames:
+            break
+        frames.extend([b'good', b'bye'])
+        router.send_multipart(frames)
+        i = i + 1
+    router.close()
+
+
+class ErrorWorker(object):
+    def __init__(self):
+        pass
+
+    def __call__(self, addr, context, poller):
+        print('call')
+        raise KeyboardInterrupt

--- a/skygear/transmitter/zmq.py
+++ b/skygear/transmitter/zmq.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import json
 import logging
-import time
 import threading
+import time
 from random import randint
 
 import zmq
@@ -63,7 +63,8 @@ class Worker(threading.Thread, CommonTransport):
     """
     Worker is a Paranoid-Pirate worker described in the zguide:
     Related RFC: https://rfc.zeromq.org/spec:6/PPP
-    refs: http://zguide.zeromq.org/py:all#Robust-Reliable-Queuing-Paranoid-Pirate-Pattern
+    refs:
+    http://zguide.zeromq.org/py:all#Robust-Reliable-Queuing-Paranoid-Pirate-Pattern
     """
     def __init__(self, z_context, addr, stopper, registry=None):
         threading.Thread.__init__(self)
@@ -71,7 +72,6 @@ class Worker(threading.Thread, CommonTransport):
         self.addr = addr
         self.z_context = z_context
         self.stopper = stopper
-        self.identity = "%04X-%04X" % (randint(0, 0x10000), randint(0, 0x10000))
 
     def run(self):
         """
@@ -97,7 +97,8 @@ class Worker(threading.Thread, CommonTransport):
                 #  - 1-part HEARTBEAT -> heartbeat
                 frames = worker.recv_multipart()
                 if not frames:
-                    log.warn('Invalid message: %s, assuming socket dead', frames)
+                    log.warn(
+                        'Invalid message: %s, assuming socket dead', frames)
                     return
 
                 if len(frames) == 3:
@@ -177,7 +178,7 @@ class ZmqTransport(CommonTransport):
 
         self._addr = addr
         self._context = context
-        self._threading = threading 
+        self._threading = threading
         self.threads = []
 
     def run(self):
@@ -192,4 +193,3 @@ class ZmqTransport(CommonTransport):
         except KeyboardInterrupt:
             log.info('Shuting down all worker')
             stopper.set()
-

--- a/skygear/transmitter/zmq.py
+++ b/skygear/transmitter/zmq.py
@@ -183,13 +183,12 @@ class ZmqTransport(CommonTransport):
 
     def run(self):
         stopper = threading.Event()
-        for i in range(0, self._threading):
+        for i in range(self._threading):
             t = Worker(self._context, self._addr, stopper)
             self.threads.append(t)
             t.start()
         try:
-            while 1:
-                time.sleep(HEARTBEAT_INTERVAL)
+            t.join()
         except KeyboardInterrupt:
             log.info('Shutting down all worker')
             stopper.set()

--- a/skygear/transmitter/zmq.py
+++ b/skygear/transmitter/zmq.py
@@ -166,7 +166,7 @@ class Worker(threading.Thread, CommonTransport):
 class ZmqTransport(CommonTransport):
     """
     ZmqTransport will start the working thread which run it own zmq socket.
-    Since the zmq socket is not thread safe, the worker will responabile for
+    Since the zmq socket is not thread safe, the worker will be responabile for
     doing their own heartbeat to the keep alive. To skygear-server it just
     like multiple worker process.
     """
@@ -191,5 +191,5 @@ class ZmqTransport(CommonTransport):
             while 1:
                 time.sleep(HEARTBEAT_INTERVAL)
         except KeyboardInterrupt:
-            log.info('Shuting down all worker')
+            log.info('Shutting down all worker')
             stopper.set()


### PR DESCRIPTION
The implementation is thread pool. By default, it open 4 thread.
Which each thread is a separate worker owning it own ZMQ socket(2). So if the
ZMQ socket limit is 1000, it can maximum open 500 thread.

connect #72