### PR TITLE
WIP: Fix register handler with different HTTP method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pycparser==2.14
 pytest==2.8.2
 pyzmq==14.7.0
 requests==2.7.0
-six==1.9.0
 SQLAlchemy==1.0.8
 strict-rfc3339==0.5
 websocket-client==0.32.0

--- a/skygear/predicate.py
+++ b/skygear/predicate.py
@@ -26,8 +26,7 @@ class Predicate(object):
     >>> p = Predicate(_id__eq="simple", gender__eq="M") #Conjuction
     >>> p = Predicate(_id__eq="simple", gender__eq="M", op=Predicate.OR) #Disjunction
     >>> p = ~Predicate(_id__eq="milktea") #Negation
-    """
-
+    """ # noqa
 
     AND = 'and'
     OR = 'or'

--- a/skygear/registry.py
+++ b/skygear/registry.py
@@ -59,16 +59,31 @@ class Registry:
 
     def _add_param(self, kind, param):
         """
-        Add a param dict to the registry. If the param already exist
-        in the registry, the existing param will be removed. An param
-        is a dictionary containing info of the declared extension point.
+        Add a extension point param dict to the registry. If another param
+        dict is a duplicate of the specified param dict, the existing param
+        dict will be removed from the registry.
+
+        An extension point param dict contains registration information of
+        an extension point (i.e. cloud function).
+
+        A param dict is duplicate of another when:
+        - for handler: having the same name and method
+        - others: having the same name
         """
+        if kind == 'handler':
+            def is_dup(a, b):
+                return a.get('name') == b.get('name') and \
+                    a.get('methods') == b.get('methods')
+        else:
+            def is_dup(a, b):
+                return a.get('name') == b.get('name')
+
         param_list = self.param_map[kind]
 
         # Check existing param. Remove it if the param has the same name
         # as the to-be-added param.
         for i in range(len(param_list)):
-            if param_list[i].get('name') == param.get('name'):
+            if is_dup(param_list[i], param):
                 del param_list[i]
                 break
         param_list.append(param)

--- a/skygear/tests/test_registry.py
+++ b/skygear/tests/test_registry.py
@@ -41,6 +41,29 @@ class TestRegistry(unittest.TestCase):
         assert param_map[0]['key_required'] is True
         assert param_map[0]['user_required'] is True
 
+    def test_register_handler_with_different_method(self):
+        def handler1():
+            pass
+
+        def handler2():
+            pass
+
+        registry = Registry()
+        registry.register_handler('plugin:handler', handler1, method='GET')
+        registry.register_handler('plugin:handler', handler2, method='POST')
+
+        assert len(registry.handler) == 1
+        assert registry.get_handler('plugin:handler', 'GET') == handler1
+        assert registry.get_handler('plugin:handler', 'POST') == handler2
+        assert registry.get_handler('plugin:handler', 'PUT') is None
+
+        param_map = registry.param_map['handler']
+        assert len(param_map) == 2
+        assert param_map[0]['name'] == 'plugin:handler'
+        assert 'GET' in param_map[0]['methods']
+        assert param_map[1]['name'] == 'plugin:handler'
+        assert 'POST' in param_map[1]['methods']
+
     def test_register_handler_twice(self):
         def handler1():
             pass


### PR DESCRIPTION
This fixes the bug when using multiple handler decorators to register the
same handler path but with different HTTP method.

connects #164