### PR TITLE
Fix register handler with different HTTP method

### DIFF
--- a/skygear/registry.py
+++ b/skygear/registry.py
@@ -65,6 +65,7 @@ class Registry:
         # the one being registered.
         for old_param in self.param_map['handler']:
             if not old_param.get('name') == param.get('name'):
+                new_param_list.append(old_param)
                 continue
 
             methods_intersection = set(old_param.get('methods')) & \

--- a/skygear/tests/test_registry.py
+++ b/skygear/tests/test_registry.py
@@ -68,16 +68,13 @@ class TestRegistry(unittest.TestCase):
         assert registry.get_handler('plugin:handler3', 'POST') == handler3
 
         param_map = registry.param_map['handler']
-        print(param_map)
         assert len(param_map) == 3
         assert param_map[0]['name'] == 'plugin:handler'
+        assert param_map[0]['methods'] == ['GET']
         assert param_map[1]['name'] == 'plugin:handler'
-        assert 'POST' in param_map[1]['methods']
-        assert 'GET' in param_map[0]['methods']
-        assert param_map[1]['name'] == 'plugin:handler'
-        assert 'POST' in param_map[1]['methods']
+        assert param_map[1]['methods'] == ['POST']
         assert param_map[2]['name'] == 'plugin:handler3'
-        assert 'POST' in param_map[2]['methods']
+        assert param_map[2]['methods'] == ['POST']
 
     def test_register_handler_twice(self):
         def handler1():

--- a/skygear/tests/test_registry.py
+++ b/skygear/tests/test_registry.py
@@ -52,22 +52,32 @@ class TestRegistry(unittest.TestCase):
         def handler2():
             pass
 
+        def handler3():
+            pass
+
         registry = Registry()
         registry.register_handler('plugin:handler', handler1,
                                   method=['GET', 'POST'])
         registry.register_handler('plugin:handler', handler2, method='POST')
+        registry.register_handler('plugin:handler3', handler3, method='POST')
 
-        assert len(registry.handler) == 1
+        assert len(registry.handler) == 2
         assert registry.get_handler('plugin:handler', 'GET') == handler1
         assert registry.get_handler('plugin:handler', 'POST') == handler2
         assert registry.get_handler('plugin:handler', 'PUT') is None
+        assert registry.get_handler('plugin:handler3', 'POST') == handler3
 
         param_map = registry.param_map['handler']
-        assert len(param_map) == 2
+        print(param_map)
+        assert len(param_map) == 3
         assert param_map[0]['name'] == 'plugin:handler'
+        assert param_map[1]['name'] == 'plugin:handler'
+        assert 'POST' in param_map[1]['methods']
         assert 'GET' in param_map[0]['methods']
         assert param_map[1]['name'] == 'plugin:handler'
         assert 'POST' in param_map[1]['methods']
+        assert param_map[2]['name'] == 'plugin:handler3'
+        assert 'POST' in param_map[2]['methods']
 
     def test_register_handler_twice(self):
         def handler1():

--- a/skygear/tests/test_registry.py
+++ b/skygear/tests/test_registry.py
@@ -35,11 +35,39 @@ class TestRegistry(unittest.TestCase):
         assert registry.get_handler('plugin:handler', 'PUT') is None
 
         param_map = registry.param_map['handler']
-        assert len(param_map) == 1
+        assert len(param_map) == 2
         assert param_map[0]['name'] == 'plugin:handler'
-        assert 'POST' in param_map[0]['methods']
+        assert 'GET' in param_map[0]['methods']
         assert param_map[0]['key_required'] is True
         assert param_map[0]['user_required'] is True
+        assert param_map[1]['name'] == 'plugin:handler'
+        assert 'POST' in param_map[1]['methods']
+        assert param_map[1]['key_required'] is True
+        assert param_map[1]['user_required'] is True
+
+    def test_register_handler_with_different_method(self):
+        def handler1():
+            pass
+
+        def handler2():
+            pass
+
+        registry = Registry()
+        registry.register_handler('plugin:handler', handler1,
+                                  method=['GET', 'POST'])
+        registry.register_handler('plugin:handler', handler2, method='POST')
+
+        assert len(registry.handler) == 1
+        assert registry.get_handler('plugin:handler', 'GET') == handler1
+        assert registry.get_handler('plugin:handler', 'POST') == handler2
+        assert registry.get_handler('plugin:handler', 'PUT') is None
+
+        param_map = registry.param_map['handler']
+        assert len(param_map) == 2
+        assert param_map[0]['name'] == 'plugin:handler'
+        assert 'GET' in param_map[0]['methods']
+        assert param_map[1]['name'] == 'plugin:handler'
+        assert 'POST' in param_map[1]['methods']
 
     def test_register_handler_twice(self):
         def handler1():
@@ -63,9 +91,9 @@ class TestRegistry(unittest.TestCase):
         assert registry.get_handler('plugin:handler', 'PUT') is None
 
         param_map = registry.param_map['handler']
-        assert len(param_map) == 1
+        assert len(param_map) == 2
         assert param_map[0]['name'] == 'plugin:handler'
-        assert 'POST' in param_map[0]['methods']
+        assert 'GET' in param_map[0]['methods']
         assert param_map[0]['key_required'] is True
         assert param_map[0]['user_required'] is True
 


### PR DESCRIPTION
This fixes the bug when using multiple handler decorators to register
the same handler path but with different HTTP method.

connects #164