### PR TITLE
Update psycopg2 for supporting postgres10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==2.0.0
 boto3==1.4.2
-psycopg2==2.6.1
+psycopg2==2.7.3.2
 py==1.4.30
 pycparser==2.14
 pytest==2.8.2


### PR DESCRIPTION
This commit objective mainly mute the version parsing error, not
intended to provide official support on postgres10
refs https://github.com/psycopg/psycopg2/issues/489