### PR TITLE
Fix unable to change record ACL settings in before save

### DIFF
--- a/skygear/models.py
+++ b/skygear/models.py
@@ -59,6 +59,10 @@ class Record:
     def acl(self):
         return self._acl
 
+    @acl.setter
+    def acl(self, value):
+        self._acl = value
+
     @property
     def created_at(self):
         return self._created_at

--- a/skygear/tests/test_models.py
+++ b/skygear/tests/test_models.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 from datetime import datetime
 
-from ..models import Record, RecordID
+from ..models import (ACCESS_CONTROL_ENTRY_LEVEL_READ,
+                      PublicAccessControlEntry, Record, RecordID)
 
 
 class TestRecord():
@@ -42,3 +43,11 @@ class TestRecord():
         assert r.id == rid
         assert r.owner_id == 'OWNER_ID'
         assert r.data == {}
+
+    def test_set_acl(eslf):
+        rid = RecordID("note", "hello_world")
+        r = Record(rid, "OWNER_ID", None)
+        r.acl = [PublicAccessControlEntry(ACCESS_CONTROL_ENTRY_LEVEL_READ)]
+
+        assert len(r.acl) == 1
+        assert r.acl[0].level == ACCESS_CONTROL_ENTRY_LEVEL_READ


### PR DESCRIPTION
The `acl` property was readable, which does not allow changes to the
record ACL by setting to the `acl` property. This commit adds a setter
to the `acl` property.