### PR TITLE
Support `async_` hook param in addition to `async`

### DIFF
--- a/skygear/registry.py
+++ b/skygear/registry.py
@@ -117,6 +117,9 @@ class Registry:
             raise ValueError("trigger is required for hook")
         kwargs['name'] = name
 
+        if 'async_' in kwargs:
+            kwargs['async'] = kwargs.pop('async_')
+
         if name in self.func_map['hook']:
             log.warning("Replacing previously registered hook '%s'.", name)
 

--- a/skygear/settings/__init__.py
+++ b/skygear/settings/__init__.py
@@ -104,7 +104,7 @@ def config_module(name, *args, **kwargs):
                 'message': 'Some message being returned'
             }
 
-        @skygear.after_save('some_record', async=True)
+        @skygear.after_save('some_record', async_=True)
         def some_record_after_save(record, original_record, db):
             return {
                 'success': True

--- a/skygear/tests/test_registry.py
+++ b/skygear/tests/test_registry.py
@@ -169,6 +169,7 @@ class TestRegistry(unittest.TestCase):
         kwargs = {
                 'type': 'note',
                 'trigger': 'beforeSave',
+                'async_': True,
                 }
         registry = Registry()
         registry.register_hook('hook_name', fn, **kwargs)
@@ -182,6 +183,7 @@ class TestRegistry(unittest.TestCase):
         assert param_map[0]['name'] == 'hook_name'
         assert param_map[0]['type'] == 'note'
         assert param_map[0]['trigger'] == 'beforeSave'
+        assert param_map[0]['async'] is True
 
     def test_register_hook_twice(self):
         def fn1():


### PR DESCRIPTION
Since `async` is a reserved word in python3.7, we can no longer use `async` as
the parameter for hook. A underscore is added at the end as per common practice
in python community.