### PR TITLE
Option should be optional when a default is specified

### DIFF
--- a/skygear/settings/parser.py
+++ b/skygear/settings/parser.py
@@ -89,7 +89,7 @@ class SettingsParser:
         if not env_var:
             env_var = name.upper()
 
-        if default:
+        if default is not None:
             required = False
 
         setting = SettingItem(name, default, atype, env_var, resolve, required)


### PR DESCRIPTION
This fixes the problem when specifying a default of '', which should
make the option become optional.